### PR TITLE
Use toner map tiles by stamen design

### DIFF
--- a/src/components/Shared/Leaflet/index.js
+++ b/src/components/Shared/Leaflet/index.js
@@ -8,7 +8,7 @@ const Leaflet = ({ children, height, ...other }) => {
     <MapContainer style={{ height }} {...other}>
       <TileLayer
         attribution='Map tiles by <a href="https://stamen.com/">Stamen Design</a>, under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        url="https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png"
+        url="https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png"
       />
       {children}
     </MapContainer>

--- a/src/components/Shared/Leaflet/index.js
+++ b/src/components/Shared/Leaflet/index.js
@@ -7,8 +7,8 @@ const Leaflet = ({ children, height, ...other }) => {
   return (
     <MapContainer style={{ height }} {...other}>
       <TileLayer
-        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution='Map tiles by <a href="https://stamen.com/">Stamen Design</a>, under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        url="https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png"
       />
       {children}
     </MapContainer>


### PR DESCRIPTION
New attempt at changing map tiles after #5 was dropped.
Do NOT merge yet, just for preview.

About the tiles: http://maps.stamen.com/#toner-lite/12/46.0556/14.5088

TODO:
* [ ] check for cookies 🍪 
* [ ] check providers privacy policy
* [ ] add info / link to our privacy policy if needed

Preview: https://deploy-preview-10--prosti-zdravniki.netlify.app/

![image](https://user-images.githubusercontent.com/319826/143541951-ca17775d-3912-49a3-ab58-90c542179524.png)