### PR TITLE
Fix/dr page zoom and quotient 68

### DIFF
--- a/src/components/DoctorCard/Map.js
+++ b/src/components/DoctorCard/Map.js
@@ -1,5 +1,6 @@
 import { MAP } from 'const';
 import Leaflet, { Markers } from 'components/Shared/Leaflet';
+import MapEvents from './MapEvents';
 
 const { GEO_LOCATION } = MAP;
 
@@ -22,7 +23,8 @@ function withLeaflet(Component) {
       center: position,
       zoom: 10,
       dragging: false,
-      zoomControl: false,
+      minZoom: MAP.MIN_ZOOM,
+      maxZoom: MAP.MAX_ZOOM,
       scrollWheelZoom: false,
       doubleClickZoom: false,
       ...other,
@@ -30,6 +32,7 @@ function withLeaflet(Component) {
     return (
       <Component {...injectedProps}>
         <Markers.LeafletMarker position={position} eventHandlers={eventHandlers} />
+        <MapEvents geoLocation={doctor?.geoLocation} />
       </Component>
     );
   };

--- a/src/components/DoctorCard/Map.js
+++ b/src/components/DoctorCard/Map.js
@@ -21,7 +21,7 @@ function withLeaflet(Component) {
 
     const injectedProps = {
       center: position,
-      zoom: 10,
+      zoom: MAP.MAX_ZOOM,
       dragging: false,
       minZoom: MAP.MIN_ZOOM,
       maxZoom: MAP.MAX_ZOOM,

--- a/src/components/DoctorCard/MapEvents.js
+++ b/src/components/DoctorCard/MapEvents.js
@@ -1,0 +1,12 @@
+import { useMapEvents } from 'react-leaflet';
+
+const MapEvents = function MapEvents({ geoLocation }) {
+  const map = useMapEvents({
+    zoomend() {
+      map.setView(geoLocation);
+    },
+  });
+  return null;
+};
+
+export default MapEvents;

--- a/src/components/DoctorCard/PageInfo.js
+++ b/src/components/DoctorCard/PageInfo.js
@@ -1,5 +1,4 @@
 import { useNavigate } from 'react-router-dom';
-import { t } from 'i18next';
 import { CardContent, Typography, Tooltip, Stack } from '@mui/material';
 
 import IconButton from '@mui/material/IconButton';

--- a/src/components/DoctorCard/PageInfo.js
+++ b/src/components/DoctorCard/PageInfo.js
@@ -64,24 +64,19 @@ const PageInfo = function PageInfo({ doctor }) {
         )}
 
         <Stack sx={{ mt: { md: 2 } }}>
-          <Tooltip title={<Shared.Tooltip.Availability />}>
-            <Stack direction="row" alignItems="center" spacing={1}>
-              <Styled.InfoWrapper>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Tooltip title={<Shared.Tooltip.HeadQuotient load={doctor.load} />}>
+              <Styled.InfoWrapper direction="row" alignItems="center" spacing={1}>
                 <Accepts accepts={accepts.toString()} />
               </Styled.InfoWrapper>
-              <Styled.InfoWrapper>
-                <Stack direction="row" alignItems="center" spacing={1}>
-                  <SingleChart size="26px" percent={doctor.availability} />
-                  <Stack>
-                    <Styled.Availability variant="caption">{availabilityText}</Styled.Availability>
-                    <Styled.Availability variant="caption">
-                      {`${t('headQuotient')} ${doctor.load}`}
-                    </Styled.Availability>
-                  </Stack>
-                </Stack>
+            </Tooltip>
+            <Tooltip title={<Shared.Tooltip.Availability />}>
+              <Styled.InfoWrapper direction="row" alignItems="center" spacing={1}>
+                <SingleChart size="26px" percent={doctor.availability} />
+                <Styled.Availability variant="caption">{availabilityText}</Styled.Availability>
               </Styled.InfoWrapper>
-            </Stack>
-          </Tooltip>
+            </Tooltip>
+          </Stack>
         </Stack>
       </div>
       <div>

--- a/src/components/DoctorCard/styles/index.js
+++ b/src/components/DoctorCard/styles/index.js
@@ -154,7 +154,6 @@ export const Availability = styled(TypographyBase)(({ theme }) => ({
   color: 'inherit',
   whiteSpace: 'nowrap',
   opacity: theme.customOpacity.half,
-  ':last-of-type': { opacity: 0.3 },
 }));
 
 export const Link = styled(MuiLink)(({ theme }) => ({


### PR DESCRIPTION
Fix: #68

- Zoom enabled, only with map buttons.
- Head quotient removed.

Wheel and double click zoom are disabled. I couldn't figured out how to keep marker in center. It's zooming on mouse position and If user is not on marker, marker moves from center. I am able to reset map center back to marker but it's annoying while map jumps back.

Initial.
![Screenshot 2021-12-05 16 16 44](https://user-images.githubusercontent.com/44704999/144752868-9ce50c7b-0a72-4065-9f68-2bcac44d7e42.png)

Zoomed in.
![Screenshot 2021-12-05 16 18 07](https://user-images.githubusercontent.com/44704999/144752653-d57196fa-d23e-48bf-ae5f-f7374df074cd.png)

Zoomed out.
![Screenshot 2021-12-05 16 23 57](https://user-images.githubusercontent.com/44704999/144752780-afe13c13-7485-42e5-97a7-82450538706d.png)
)



