### PR TITLE
Properly slugify doctor names

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-router": "^6.0.2",
     "react-router-dom": "^6.0.2",
     "react-scripts": "4.0.3",
+    "slugify": "^1.6.3",
     "uuid": "^8.3.2",
     "web-vitals": "^1.0.1"
   },

--- a/src/components/DoctorCard/Info.js
+++ b/src/components/DoctorCard/Info.js
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { CardContent, Typography, Tooltip, IconButton, Stack } from '@mui/material';
+import slugify from 'slugify';
 
 import * as Icons from 'components/Shared/Icons';
 import SingleChart from 'components/Shared/CircleChart';
@@ -22,7 +23,8 @@ const Info = function Info({ doctor, handleZoom = () => {} }) {
       return undefined;
     }
 
-    const path = `/${lng}/${drPath}/${doctor?.name?.toLowerCase().replaceAll(' ', '-')}`;
+    const slug = slugify(doctor?.name?.toLowerCase());
+    const path = `/${lng}/${drPath}/${slug}`;
     // todo pass filters' state as second argument
     return navigate(path);
   };

--- a/src/pages/Doctor.js
+++ b/src/pages/Doctor.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import slugify from 'slugify';
 import Box from '@mui/material/Box';
 
 import DoctorCard from 'components/DoctorCard';
@@ -15,7 +16,7 @@ const Doctor = function Doctor() {
 
   useEffect(() => {
     allDoctors?.find(aDoctor => {
-      if (aDoctor.name.toLowerCase() === priimekIme.replaceAll('-', ' ')) {
+      if (slugify(aDoctor.name.toLowerCase()) === priimekIme) {
         setDoctor(aDoctor);
       }
       return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10564,6 +10564,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+slugify@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.3.tgz#325aec50871acfb17976f2d3cb09ee1e7ab563be"
+  integrity sha512-1MPyqnIhgiq+/0iDJyqSJHENdnH5MMIlgJIBxmkRMzTNKlS/QsN5dXsB+MdDq4E6w0g9jFA4XOTRkVDjDae/2w==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
Instead of replacing " " with "-" and back

Uses https://www.npmjs.com/package/slugify

It fixes URLs for doctors with "-" in their name or surname

It is transliterating "đ" to "dj", so eg `Đorđević Stevan` gets the url `djordjevic-stevan` which might not be ideal

