### PR TITLE
Fix menu drawer stays open #78

### DIFF
--- a/src/components/Header/Drawer.js
+++ b/src/components/Header/Drawer.js
@@ -49,6 +49,7 @@ const TemporaryDrawer = function TemporaryDrawer({ open, setOpen }) {
       open={open}
       onClose={toggleDrawer}
       transitionDuration={{ enter: 1500, exit: 1250 }}
+      sx={{ display: { md: 'none' } }}
     >
       <Styled.StackSmall id="nav-links-drawer" onClick={eventHandler}>
         <Stack


### PR DESCRIPTION
Fix #78

1. Open any page in a narrow screen
2. Open the hamburger menu
3. Resize the page to desktop size
4. Drawer (sidebar) not visible but state is preserved. 
5. Resize to narrow.
6. Drawer visible.
