### PR TITLE
fix(Doctors): 💄 map attribution out of view

### DIFF
--- a/src/components/Doctors/styles/index.js
+++ b/src/components/Doctors/styles/index.js
@@ -28,10 +28,10 @@ export const WrapperInfinite = styled('div')(({ theme }) => ({
     height: `calc(100vh - ${SIZES.MAP_HEIGHT.upSmall} - 56px - 140.5px)`,
   },
   [theme.breakpoints.up('md')]: {
-    height: 'calc(100vh - 64px - 91px)',
+    height: 'calc(100vh - 64px - 107px)',
   },
   [theme.breakpoints.up('lg')]: {
-    height: 'calc(100vh - 64px - 54px)',
+    height: 'calc(100vh - 64px - 65.5px)',
   },
 }));
 export const InfiniteScroll = styled(BaseInfiniteScroll)(({ theme }) => ({

--- a/src/pages/styles/Home.js
+++ b/src/pages/styles/Home.js
@@ -20,7 +20,7 @@ export const Box = styled(MuiBox)(({ theme }) => ({
   },
   [theme.breakpoints.up('md')]: {
     '& .leaflet-container': {
-      height: 'clamp(400px, 100%, 100vh)', // ? not sure but it's working
+      height: '100%',
     },
   },
 }));


### PR DESCRIPTION
Due to infinite scroll height map height was too big.

FIX: #86. 

I guess this should be merged only if new design will not be implemented #89.