### PR TITLE
Set search input type & use full width

### DIFF
--- a/src/components/Filters/Search.js
+++ b/src/components/Filters/Search.js
@@ -53,6 +53,7 @@ const Search = function Search() {
             value={value}
             onChange={handleSearchChange}
             aria-label="search"
+            type="search"
           />
         </Styled.Search.Search>
       </Paper>

--- a/src/components/Filters/styles/Search.js
+++ b/src/components/Filters/styles/Search.js
@@ -41,15 +41,7 @@ export const InputBase = styled(MuiInputBase)(({ theme }) => ({
     padding: theme.spacing(0, 1, 0, 0),
     // vertical padding + font size from searchIcon
     paddingLeft: `calc(1em + ${theme.spacing(4)})`,
-    width: '20ch',
     borderRadius: '24px',
-
-    [theme.breakpoints.up('sm')]: {
-      width: '20ch',
-      '&:focus': {
-        width: '20ch',
-      },
-    },
   },
 }));
 


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/319826/146276061-8e419836-e60a-4a8b-8749-1363279d390b.png)

after:
![image](https://user-images.githubusercontent.com/319826/146276117-8ae1507f-a169-497b-a753-1b919d1b177c.png)

`<input>` HTML element:
* uses full width of parent container (removed `width: 20ch` css) and
* is set to `type='search'` (https://caniuse.com/input-search) to give it a x at the end for easy clearing (not sure if there is another, more MUI-esque way to do so)