### PR TITLE
fix: 💄 no border radius if age group not present

### DIFF
--- a/src/components/DoctorCard/Shared/index.js
+++ b/src/components/DoctorCard/Shared/index.js
@@ -65,18 +65,32 @@ export const DoubleChip = function DoubleChip({ type, ageGroup }) {
   const drAgeGroup = t(AgeGroupTranslate?.[ageGroup] ?? 'adults');
   const typeIcon = TypeIconTranslate[type] ?? 'Family';
   const ageGroupIcon = AgeGroupIconTranslate?.[ageGroup] ?? 'Adults';
+
+  const isDentist = type === 'den';
+
+  const first = isDentist ? (
+    <Styled.PageInfo.First direction="row" component="span" spacing={1}>
+      <Icons.Icon name={typeIcon} className="icon" />
+      <span className="text">{t(`${drType}`)}</span>
+    </Styled.PageInfo.First>
+  ) : (
+    <Styled.PageInfo.First single direction="row" component="span" spacing={1}>
+      <Icons.Icon name={typeIcon} className="icon" />
+      <span className="text">{t(`${drType}`)}</span>
+    </Styled.PageInfo.First>
+  );
+
+  const second = isDentist && (
+    <Styled.PageInfo.Second direction="row" component="span" spacing={1}>
+      <span className="text">{t(`${drAgeGroup}`)}</span>
+      <Icons.Icon name={ageGroupIcon} className="icon" />
+    </Styled.PageInfo.Second>
+  );
+
   return (
     <Styled.PageInfo.DCWrapper direction="row">
-      <Styled.PageInfo.First direction="row" component="span" spacing={1}>
-        <Icons.Icon name={typeIcon} className="icon" />
-        <span className="text">{t(`${drType}`)}</span>
-      </Styled.PageInfo.First>
-      {type === 'den' && (
-        <Styled.PageInfo.Second direction="row" component="span" spacing={1}>
-          <span className="text">{t(`${drAgeGroup}`)}</span>
-          <Icons.Icon name={ageGroupIcon} className="icon" />
-        </Styled.PageInfo.Second>
-      )}
+      {first}
+      {second}
     </Styled.PageInfo.DCWrapper>
   );
 };

--- a/src/components/DoctorCard/styles/PageInfo.js
+++ b/src/components/DoctorCard/styles/PageInfo.js
@@ -17,10 +17,10 @@ export const DCWrapper = styled(Stack)(({ theme }) => ({
   },
 }));
 
-export const First = styled(Stack)(({ theme }) => ({
+export const First = styled(Stack)(({ theme, single }) => ({
   backgroundColor: theme.customColors.doctor.colors.chipBcg1,
   padding: '6px 8px',
-  borderRadius: '5px 0 0 5px',
+  borderRadius: single ? '5px' : '5px 0 0 5px',
 }));
 export const Second = styled(Stack)(({ theme }) => ({
   backgroundColor: theme.customColors.doctor.colors.chipBcg2,


### PR DESCRIPTION
Difference is not so obvious.


before:
![gp-dr-page-chip-before](https://user-images.githubusercontent.com/44704999/147121571-549d898e-868f-4160-80db-6d8bc327e0dc.png)

after:
![gp-dr-page-chip-after](https://user-images.githubusercontent.com/44704999/147121599-c3c683db-2525-493f-8f4e-81bf507f73a6.png)

