### PR TITLE
FIX: Remove card area click to go to the dr page

### DIFF
--- a/src/components/DoctorCard/Info.js
+++ b/src/components/DoctorCard/Info.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
-  CardActionArea,
   CardActions,
   CardContent,
   Divider,

--- a/src/components/DoctorCard/Info.js
+++ b/src/components/DoctorCard/Info.js
@@ -57,40 +57,38 @@ const Info = function Info({ doctor, handleZoom = () => {}, isMarker = false }) 
 
   return (
     <>
-      <CardActionArea href={path} onClick={e => handleDoctorCard(e, false)}>
-        <CardContent>
-          <Typography component="h2" variant="h2">
-            <Shared.LinkNoRel href={path} onClick={e => handleDoctorCard(e, false)}>
-              {doctor.name}
-            </Shared.LinkNoRel>
-          </Typography>
-          {isMarker && <Shared.DoubleChip type={type} ageGroup={ageGroup} />}
-          <Typography component="h3" variant="h3">
-            {doctor.provider}
-          </Typography>
-          <Typography component="address" variant="body2">
-            {doctor.fullAddress}
-          </Typography>
+      <CardContent>
+        <Typography component="h2" variant="h2">
+          <Shared.LinkNoRel href={path} onClick={e => handleDoctorCard(e, false)}>
+            {doctor.name}
+          </Shared.LinkNoRel>
+        </Typography>
+        {isMarker && <Shared.DoubleChip type={type} ageGroup={ageGroup} />}
+        <Typography component="h3" variant="h3">
+          {doctor.provider}
+        </Typography>
+        <Typography component="address" variant="body2">
+          {doctor.fullAddress}
+        </Typography>
 
-          <Stack direction={isMarker ? 'column' : 'row'} justifyContent="space-between">
-            <Stack direction="row" alignItems="center" spacing={1}>
-              <Tooltip title={<Shared.Tooltip.HeadQuotient load={doctor.load} />}>
-                <Styled.InfoWrapper direction="row" alignItems="center" spacing={1}>
-                  <Accepts accepts={accepts} />
-                </Styled.InfoWrapper>
-              </Tooltip>
-              <Tooltip title={<Shared.Tooltip.Availability />}>
-                <Styled.InfoWrapper direction="row" alignItems="center" spacing={1}>
-                  <SingleChart size="26px" percent={doctor.availability} />
-                  <Stack>
-                    <Styled.Availability variant="caption">{availabilityText}</Styled.Availability>
-                  </Stack>
-                </Styled.InfoWrapper>
-              </Tooltip>
-            </Stack>
+        <Stack direction={isMarker ? 'column' : 'row'} justifyContent="space-between">
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Tooltip title={<Shared.Tooltip.HeadQuotient load={doctor.load} />}>
+              <Styled.InfoWrapper direction="row" alignItems="center" spacing={1}>
+                <Accepts accepts={accepts} />
+              </Styled.InfoWrapper>
+            </Tooltip>
+            <Tooltip title={<Shared.Tooltip.Availability />}>
+              <Styled.InfoWrapper direction="row" alignItems="center" spacing={1}>
+                <SingleChart size="26px" percent={doctor.availability} />
+                <Stack>
+                  <Styled.Availability variant="caption">{availabilityText}</Styled.Availability>
+                </Stack>
+              </Styled.InfoWrapper>
+            </Tooltip>
           </Stack>
-        </CardContent>
-      </CardActionArea>
+        </Stack>
+      </CardContent>
       <CardActions>
         <div>
           <IconButton

--- a/src/components/DoctorCard/styles/index.js
+++ b/src/components/DoctorCard/styles/index.js
@@ -115,11 +115,12 @@ export const InfoCard = styled(Card)(({ theme, accepts }) => {
     display: 'flex',
     '.MuiCardContent-root': {
       padding: '20px 24px 10px',
+      flexGrow: 1,
     },
     '.MuiCardActions-root': {
       padding: '15px 10px',
       display: 'flex',
-      flexGrow: 1,
+
       '> div': {
         display: 'flex',
         height: '100%',


### PR DESCRIPTION
leave link on the title and in the menu.
Institution links can't be clicked and tooltips can't be triggered on mobile if the whole card area is clickable.