### PR TITLE
fix: 🐛 filter state isn't preserved on return from

### DIFF
--- a/src/components/DoctorCard/Info.js
+++ b/src/components/DoctorCard/Info.js
@@ -43,7 +43,14 @@ const Info = function Info({ doctor, handleZoom = () => {}, isMarker = false }) 
     if (isReportError) {
       path = `/${lng}/${drPath}/${slug}/edit`;
     }
-    return navigate(path, { state: { zoom: map?.getZoom(), center: map?.getCenter() } });
+    return navigate(path, {
+      state: {
+        zoom: map?.getZoom(),
+        center: map?.getCenter(),
+        type,
+        ageGroup: ageGroup ?? 'adults',
+      },
+    });
   };
 
   const [moreMenuAnchorEl, setMoreMenuAnchorEl] = React.useState(null);

--- a/src/components/DoctorCard/PageInfo.js
+++ b/src/components/DoctorCard/PageInfo.js
@@ -16,6 +16,7 @@ import * as Styled from './styles';
 import * as Shared from './Shared';
 
 import { toPercent } from './utils';
+import { AgeGroupTranslate } from './dicts';
 
 const PageInfo = function PageInfo({ doctor, isReportError }) {
   const { searchValue } = useFilter();
@@ -37,6 +38,8 @@ const PageInfo = function PageInfo({ doctor, isReportError }) {
         searchValue,
         zoom: state?.zoom ?? MAP.ZOOM,
         center: state?.center ?? MAP.GEO_LOCATION.SL_CENTER,
+        type,
+        ageGroup: AgeGroupTranslate[ageGroup] ?? 'adults',
       },
     });
   };

--- a/src/components/Filters/ToggleDoctorType.js
+++ b/src/components/Filters/ToggleDoctorType.js
@@ -10,7 +10,10 @@ function withToggleGroup(Component) {
   return function ToggleDoctorType(props) {
     const { state } = useLocation();
 
-    const { type: stateType, ageGroup: stateAgeGroup } = state;
+    const { type: stateType, ageGroup: stateAgeGroup } = state ?? {
+      type: 'gp',
+      ageGroup: 'adults',
+    };
 
     const { doctorType, setDoctorType } = useFilter();
     const [drType, setDrType] = useState(stateType ?? 'gp');

--- a/src/components/Filters/ToggleDoctorType.js
+++ b/src/components/Filters/ToggleDoctorType.js
@@ -3,13 +3,18 @@ import ToggleGroup from 'components/Shared/ToggleGroup';
 import { useFilter } from 'context/filterContext';
 import { t } from 'i18next';
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
 import { IconToggleButton } from './Shared';
 
 function withToggleGroup(Component) {
   return function ToggleDoctorType(props) {
+    const { state } = useLocation();
+
+    const { type: stateType, ageGroup: stateAgeGroup } = state;
+
     const { doctorType, setDoctorType } = useFilter();
-    const [drType, setDrType] = useState('gp');
-    const [ageGroup, setAgeGroup] = useState('adults');
+    const [drType, setDrType] = useState(stateType ?? 'gp');
+    const [ageGroup, setAgeGroup] = useState(stateAgeGroup ?? 'adults');
 
     const injectedPropsDrType = {
       ...props,


### PR DESCRIPTION
doctor's page