### PR TITLE
Refactor tooltips

### DIFF
--- a/src/components/DoctorCard/Info/index.js
+++ b/src/components/DoctorCard/Info/index.js
@@ -64,7 +64,6 @@ const Info = function Info({ doctor, handleZoom = () => {}, isMarker = false }) 
             />
             <Shared.Availability
               availability={doctor.availability}
-              override={doctor.availabilityOverride}
               date={doctor.updatedAt && doctor.formatUpdatedAt(lng)}
               hasOverride={doctor.availabilityOverride ? true : undefined}
             />

--- a/src/components/DoctorCard/Info/index.js
+++ b/src/components/DoctorCard/Info/index.js
@@ -10,7 +10,6 @@ import * as Shared from '../Shared';
 const Info = function Info({ doctor, handleZoom = () => {}, isMarker = false }) {
   const { lng } = useParams();
   const { map } = useLeafletContext();
-  const accepts = doctor.accepts === 'y';
   const [type, ageGroup] = doctor.type.split('-');
 
   const navigate = useNavigate();
@@ -60,7 +59,7 @@ const Info = function Info({ doctor, handleZoom = () => {}, isMarker = false }) 
               load={doctor.load}
               note={doctor.note}
               date={doctor.updatedAt && doctor.formatUpdatedAt(lng)}
-              accepts={accepts}
+              accepts={doctor.accepts}
               hasOverride={doctor.acceptsOverride || doctor.note ? true : undefined}
             />
             <Shared.Availability

--- a/src/components/DoctorCard/Info/index.js
+++ b/src/components/DoctorCard/Info/index.js
@@ -61,10 +61,12 @@ const Info = function Info({ doctor, handleZoom = () => {}, isMarker = false }) 
               note={doctor.note}
               date={doctor.updatedAt && doctor.formatUpdatedAt(lng)}
               accepts={accepts}
+              hasOverride={doctor.acceptsOverride || doctor.note ? true : undefined}
             />
             <Shared.Availability
               availability={doctor.availability}
               date={doctor.updatedAt && doctor.formatUpdatedAt(lng)}
+              hasOverride={doctor.availabilityOverride ? true : undefined}
             />
           </Stack>
         </Stack>

--- a/src/components/DoctorCard/PageInfo/index.js
+++ b/src/components/DoctorCard/PageInfo/index.js
@@ -100,10 +100,12 @@ const PageInfo = function PageInfo({ doctor, isReportError }) {
               note={doctor.note}
               date={doctor.updatedAt && doctor.formatUpdatedAt(lng)}
               accepts={accepts}
+              hasOverride={doctor.acceptsOverride || doctor.note ? true : undefined}
             />
             <Shared.Availability
               availability={doctor.availability}
               date={doctor.updatedAt && doctor.formatUpdatedAt(lng)}
+              hasOverride={doctor.availabilityOverride ? true : undefined}
             />
           </Stack>
         </Stack>
@@ -171,7 +173,16 @@ const PageInfo = function PageInfo({ doctor, isReportError }) {
           {doctor.updatedAt && (
             <Styled.PageInfo.Changed
               className="updated-label"
-              title={<Shared.Tooltip.Updated doctor={doctor} />}
+              title={
+                <Shared.Tooltip.Updated
+                  date={doctor.formatUpdatedAt(lng)}
+                  note={doctor.note}
+                  acceptsOverride={doctor.acceptsOverride}
+                  acceptsZZZS={doctor.acceptsZZZS}
+                  availabilityOverride={doctor.availabilityOverride}
+                  availabilityZZZS={doctor.availabilityZZZS}
+                />
+              }
               leaveTouchDelay={3000}
               enterTouchDelay={50}
             >

--- a/src/components/DoctorCard/PageInfo/index.js
+++ b/src/components/DoctorCard/PageInfo/index.js
@@ -21,7 +21,6 @@ const PageInfo = function PageInfo({ doctor, isReportError }) {
   const { state } = useLocation();
 
   const { lng } = useParams();
-  const accepts = doctor.accepts === 'y';
 
   const [type, ageGroup] = doctor.type.split('-');
 
@@ -99,7 +98,7 @@ const PageInfo = function PageInfo({ doctor, isReportError }) {
               load={doctor.load}
               note={doctor.note}
               date={doctor.updatedAt && doctor.formatUpdatedAt(lng)}
-              accepts={accepts}
+              accepts={doctor.accepts}
               hasOverride={doctor.acceptsOverride || doctor.note ? true : undefined}
             />
             <Shared.Availability

--- a/src/components/DoctorCard/PageInfo/index.js
+++ b/src/components/DoctorCard/PageInfo/index.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { CardContent, Typography, Stack, Alert } from '@mui/material';
+import { CardContent, Typography, Stack, Alert, Tooltip } from '@mui/material';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -170,8 +170,7 @@ const PageInfo = function PageInfo({ doctor, isReportError }) {
           </Styled.PageInfo.BackWrapper>
 
           {doctor.updatedAt && (
-            <Styled.PageInfo.Changed
-              className="updated-label"
+            <Tooltip
               title={
                 <Shared.Tooltip.Updated
                   date={doctor.formatUpdatedAt(lng)}
@@ -185,10 +184,10 @@ const PageInfo = function PageInfo({ doctor, isReportError }) {
               leaveTouchDelay={3000}
               enterTouchDelay={50}
             >
-              <Styled.InfoWrapper direction="row" alignItems="center" spacing={1}>
+              <Styled.PageInfo.Override direction="row" alignItems="center" spacing={1}>
                 <Icons.Icon name="Edit" /> {doctor.formatUpdatedAt(lng)}
-              </Styled.InfoWrapper>
-            </Styled.PageInfo.Changed>
+              </Styled.PageInfo.Override>
+            </Tooltip>
           )}
         </Stack>
       </Styled.PageInfo.ToolbarWrapper>

--- a/src/components/DoctorCard/PageInfo/index.js
+++ b/src/components/DoctorCard/PageInfo/index.js
@@ -103,7 +103,6 @@ const PageInfo = function PageInfo({ doctor, isReportError }) {
             />
             <Shared.Availability
               availability={doctor.availability}
-              override={doctor.availabilityOverride}
               date={doctor.updatedAt && doctor.formatUpdatedAt(lng)}
               hasOverride={doctor.availabilityOverride ? true : undefined}
             />

--- a/src/components/DoctorCard/Shared/Accepts.js
+++ b/src/components/DoctorCard/Shared/Accepts.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import * as Styled from '../styles';
 
 const Accepts = function Accepts({ accepts }) {
-  const iconName = accepts ? 'CheckGreen' : 'BanRed';
-  const text = accepts ? t('accepts').toUpperCase() : t('rejects').toUpperCase();
+  const iconName = accepts === 'y' ? 'CheckGreen' : 'BanRed';
+  const text = accepts === 'y' ? t('accepts').toUpperCase() : t('rejects').toUpperCase();
 
   return (
     <Styled.AcceptsStack direction="row" accepts={accepts}>
@@ -16,7 +16,7 @@ const Accepts = function Accepts({ accepts }) {
 };
 
 Accepts.propTypes = {
-  accepts: PropTypes.bool.isRequired,
+  accepts: PropTypes.oneOf(['y', 'n']).isRequired,
 };
 
 export default Accepts;

--- a/src/components/DoctorCard/Shared/Tooltips.js
+++ b/src/components/DoctorCard/Shared/Tooltips.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
@@ -5,9 +7,6 @@ import { useTranslation } from 'react-i18next';
 import { styled } from '@mui/material/styles';
 import { useParams } from 'react-router-dom';
 import { toPercent } from '../utils';
-
-const getAcceptText = (accepts, translationFunc) =>
-  accepts === 'y' ? translationFunc('accepts') : translationFunc('rejects');
 
 export const HeadQuotient = function HeadQuotient({ load, note, date, hasOverride }) {
   const { t } = useTranslation();
@@ -31,6 +30,17 @@ export const HeadQuotient = function HeadQuotient({ load, note, date, hasOverrid
       )}
     </Stack>
   );
+};
+
+HeadQuotient.defaultProps = {
+  hasOverride: undefined,
+};
+
+HeadQuotient.propTypes = {
+  load: PropTypes.string.isRequired,
+  note: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(undefined)]).isRequired,
+  date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(undefined)]).isRequired,
+  hasOverride: PropTypes.bool,
 };
 
 export const Availability = function Availability({ date, hasOverride }) {
@@ -63,8 +73,8 @@ export const Updated = function Updated({
 
   const { lng } = useParams();
 
-  const acceptsOverrideText = getAcceptText(acceptsOverride, t);
-  const acceptsZZZSText = getAcceptText(acceptsZZZS, t);
+  const acceptsOverrideText = acceptsOverride === 'y' ? t('accepts') : t('rejects');
+  const acceptsZZZSText = acceptsZZZS === 'y' ? t('accepts') : t('rejects');
 
   const availabilityZZZSText = toPercent(availabilityZZZS, lng);
   const availabilityOverrideText = toPercent(availabilityOverride, lng);
@@ -95,3 +105,13 @@ export const TooltipDivider = styled(Divider)(() => ({
   borderColor: 'rgba(255,255,255,0.5)',
   margin: '5px 0',
 }));
+
+Updated.propTypes = {
+  note: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(undefined)]).isRequired,
+  date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(undefined)]).isRequired,
+  acceptsZZZS: PropTypes.oneOf(['y', 'n']).isRequired,
+  availabilityZZZS: PropTypes.string.isRequired,
+  acceptsOverride: PropTypes.oneOf(['y', 'n', undefined]).isRequired,
+  availabilityOverride: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(undefined)])
+    .isRequired,
+};

--- a/src/components/DoctorCard/Shared/Tooltips.js
+++ b/src/components/DoctorCard/Shared/Tooltips.js
@@ -6,14 +6,17 @@ import { styled } from '@mui/material/styles';
 import { useParams } from 'react-router-dom';
 import { toPercent } from '../utils';
 
-export const HeadQuotient = function HeadQuotient({ load, note, date }) {
+const getAcceptText = (accepts, translationFunc) =>
+  accepts === 'y' ? translationFunc('accepts') : translationFunc('rejects');
+
+export const HeadQuotient = function HeadQuotient({ load, note, date, hasOverride }) {
   const { t } = useTranslation();
 
   return (
     <Stack sx={{ textAlign: 'center' }}>
       <Typography variant="caption">{t('headQuotient')}</Typography>
       <Typography variant="body2">{parseFloat(load)}</Typography>
-      {date && (
+      {hasOverride && (
         <>
           <TooltipDivider />
           <Stack sx={{ textAlign: 'start' }}>
@@ -30,13 +33,13 @@ export const HeadQuotient = function HeadQuotient({ load, note, date }) {
   );
 };
 
-export const Availability = function Availability({ date }) {
+export const Availability = function Availability({ date, hasOverride }) {
   const { t } = useTranslation();
 
   return (
     <Stack>
       <Typography variant="caption">{t('doctorAvailability')}</Typography>
-      {date && (
+      {hasOverride && (
         <>
           <TooltipDivider />
           <Typography variant="caption">
@@ -48,34 +51,41 @@ export const Availability = function Availability({ date }) {
   );
 };
 
-export const Updated = function Updated({ doctor }) {
+export const Updated = function Updated({
+  date,
+  acceptsOverride,
+  availabilityOverride,
+  acceptsZZZS,
+  availabilityZZZS,
+  note,
+}) {
   const { t } = useTranslation();
 
   const { lng } = useParams();
-  const hasOverride = doctor.availabilityOverride || doctor.note;
 
-  const availabilityZZZS = toPercent(doctor.availabilityZZZS, lng);
-  const availabilityOverride = toPercent(doctor.availabilityOverride, lng);
+  const acceptsOverrideText = getAcceptText(acceptsOverride, t);
+  const acceptsZZZSText = getAcceptText(acceptsZZZS, t);
+
+  const availabilityZZZSText = toPercent(availabilityZZZS, lng);
+  const availabilityOverrideText = toPercent(availabilityOverride, lng);
 
   return (
     <Stack sx={{ textAlign: 'left' }}>
       <Typography variant="caption">
         {t('changedOn')}
-        {doctor.formatUpdatedAt(lng)}
+        {date}
       </Typography>
-      {hasOverride && (
-        <>
-          <TooltipDivider />
-          <Typography variant="caption">
-            {doctor.note && <p>{doctor.note}</p>}
-            {doctor.availabilityOverride && (
-              <p>
-                {t('doctorAvailabilityLabel')}: {availabilityZZZS} →{' '}
-                <strong>{availabilityOverride}</strong>
-              </p>
-            )}
-          </Typography>
-        </>
+      <TooltipDivider />
+      {note && <Typography variant="caption">{note}</Typography>}
+      {availabilityOverride && (
+        <Typography variant="caption">
+          {t('doctorAvailabilityLabel')}: {availabilityZZZSText} → {availabilityOverrideText}
+        </Typography>
+      )}
+      {acceptsOverride && (
+        <Typography variant="caption">
+          {acceptsZZZSText} → {acceptsOverrideText}
+        </Typography>
       )}
     </Stack>
   );

--- a/src/components/DoctorCard/Shared/Tooltips.js
+++ b/src/components/DoctorCard/Shared/Tooltips.js
@@ -45,7 +45,6 @@ HeadQuotient.propTypes = {
 
 export const Availability = function Availability({ date, hasOverride }) {
   const { t } = useTranslation();
-  const hasOverride = override;
 
   return (
     <Stack>

--- a/src/components/DoctorCard/Shared/Tooltips.js
+++ b/src/components/DoctorCard/Shared/Tooltips.js
@@ -45,7 +45,6 @@ HeadQuotient.propTypes = {
 
 export const Availability = function Availability({ date, hasOverride }) {
   const { t } = useTranslation();
-
   return (
     <Stack>
       <Typography variant="caption">{t('doctorAvailability')}</Typography>
@@ -107,11 +106,11 @@ export const TooltipDivider = styled(Divider)(() => ({
 }));
 
 Updated.propTypes = {
-  note: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(undefined)]).isRequired,
-  date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(undefined)]).isRequired,
+  note: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
   acceptsZZZS: PropTypes.oneOf(['y', 'n']).isRequired,
   availabilityZZZS: PropTypes.string.isRequired,
-  acceptsOverride: PropTypes.oneOf(['y', 'n', undefined]).isRequired,
+  acceptsOverride: PropTypes.oneOf(['y', 'n', '']).isRequired,
   availabilityOverride: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(undefined)])
     .isRequired,
 };

--- a/src/components/DoctorCard/Shared/index.js
+++ b/src/components/DoctorCard/Shared/index.js
@@ -63,10 +63,12 @@ export const DoubleChip = function DoubleChip({ type, ageGroup }) {
   );
 };
 
-export const HeadQuotient = function HeadQuotient({ load, note, date, accepts }) {
+export const HeadQuotient = function HeadQuotient({ load, note, date, accepts, hasOverride }) {
   return (
     <Tooltip
-      title={<Tooltips.HeadQuotient load={load} note={note} date={date} />}
+      title={
+        <Tooltips.HeadQuotient load={load} note={note} date={date} hasOverride={hasOverride} />
+      }
       leaveTouchDelay={3000}
       enterTouchDelay={50}
     >
@@ -77,13 +79,13 @@ export const HeadQuotient = function HeadQuotient({ load, note, date, accepts })
   );
 };
 
-export const Availability = function Availability({ date, availability }) {
+export const Availability = function Availability({ date, availability, hasOverride }) {
   const { lng } = useParams();
   const availabilityText = toPercent(availability, lng);
 
   return (
     <Tooltip
-      title={<Tooltips.Availability date={date} />}
+      title={<Tooltips.Availability date={date} hasOverride={hasOverride} />}
       leaveTouchDelay={3000}
       enterTouchDelay={50}
     >

--- a/src/components/DoctorCard/Shared/index.js
+++ b/src/components/DoctorCard/Shared/index.js
@@ -39,13 +39,8 @@ export const DoubleChip = function DoubleChip({ type, ageGroup }) {
 
   const isDentist = type === 'den';
 
-  const first = isDentist ? (
-    <Styled.PageInfo.First direction="row" component="span" spacing={1}>
-      <Icons.Icon name={typeIcon} className="icon" />
-      <span className="text">{t(`${drType}`)}</span>
-    </Styled.PageInfo.First>
-  ) : (
-    <Styled.PageInfo.First single direction="row" component="span" spacing={1}>
+  const first = (
+    <Styled.PageInfo.First single={!isDentist ? 1 : 0} direction="row" component="span" spacing={1}>
       <Icons.Icon name={typeIcon} className="icon" />
       <span className="text">{t(`${drType}`)}</span>
     </Styled.PageInfo.First>

--- a/src/components/DoctorCard/Shared/index.js
+++ b/src/components/DoctorCard/Shared/index.js
@@ -2,11 +2,12 @@ import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '@mui/material/Tooltip';
 
+import PropTypes from 'prop-types';
+
 import SingleChart from 'components/Shared/CircleChart';
 import * as Icons from 'components/Shared/Icons';
 
 import Accepts from './Accepts';
-import * as Tooltips from './Tooltips';
 
 import {
   TypeTranslate,
@@ -17,6 +18,8 @@ import {
 import * as Styled from '../styles';
 
 import { toPercent } from '../utils';
+
+import * as Tooltips from './Tooltips';
 
 export * as Tooltip from './Tooltips';
 
@@ -63,6 +66,15 @@ export const DoubleChip = function DoubleChip({ type, ageGroup }) {
   );
 };
 
+DoubleChip.defaultProps = {
+  ageGroup: undefined,
+};
+
+DoubleChip.propTypes = {
+  type: PropTypes.string.isRequired,
+  ageGroup: PropTypes.oneOf([undefined, 'students', 'youth']),
+};
+
 export const HeadQuotient = function HeadQuotient({ load, note, date, accepts, hasOverride }) {
   return (
     <Tooltip
@@ -77,6 +89,18 @@ export const HeadQuotient = function HeadQuotient({ load, note, date, accepts, h
       </Styled.InfoWrapper>
     </Tooltip>
   );
+};
+
+HeadQuotient.defaultProps = {
+  hasOverride: false,
+};
+
+HeadQuotient.propTypes = {
+  date: PropTypes.string.isRequired,
+  note: PropTypes.string.isRequired,
+  load: PropTypes.string.isRequired,
+  accepts: PropTypes.oneOf(['y', 'n']).isRequired,
+  hasOverride: PropTypes.bool,
 };
 
 export const Availability = function Availability({ date, availability, hasOverride }) {
@@ -95,4 +119,14 @@ export const Availability = function Availability({ date, availability, hasOverr
       </Styled.InfoWrapper>
     </Tooltip>
   );
+};
+
+Availability.defaultProps = {
+  hasOverride: false,
+};
+
+Availability.propTypes = {
+  date: PropTypes.string.isRequired,
+  availability: PropTypes.string.isRequired,
+  hasOverride: PropTypes.bool,
 };

--- a/src/components/DoctorCard/styles/PageInfo.js
+++ b/src/components/DoctorCard/styles/PageInfo.js
@@ -1,7 +1,6 @@
 import { styled } from '@mui/material/styles';
 
 import Stack from '@mui/material/Stack';
-import { Tooltip } from '@mui/material';
 
 export const DCWrapper = styled(Stack)(({ theme }) => ({
   color: theme.customColors.doctor.colors.chip,
@@ -97,7 +96,9 @@ export const BackWrapper = styled(Stack)(({ theme }) => ({
   },
 }));
 
-export const Changed = styled(Tooltip)(({ theme }) => ({
+export const Override = styled(Stack)(({ theme }) => ({
+  cursor: 'help',
+  minWidth: '74.5px',
   fontSize: '12px',
   color: theme.customColors.textLight,
   whiteSpace: 'nowrap',

--- a/src/components/DoctorCard/styles/index.js
+++ b/src/components/DoctorCard/styles/index.js
@@ -200,7 +200,7 @@ export const InfoWrapper = styled(Stack)(({ theme }) => ({
 }));
 
 export const AcceptsStack = styled(Stack)(({ theme, accepts }) => {
-  const color = accepts ? theme.customColors.successDark : theme.customColors.danger;
+  const color = accepts === 'y' ? theme.customColors.successDark : theme.customColors.danger;
 
   return {
     fontWeight: 700,

--- a/src/services/doctors.js
+++ b/src/services/doctors.js
@@ -63,14 +63,20 @@ export function createDoctor(doctor, institution) {
     get accepts() {
       return accepts;
     },
-    get availabilityZZZS() {
-      return availabilityZZZS;
+    get acceptsOverride() {
+      return acceptsOverride;
+    },
+    get acceptsZZZS() {
+      return acceptsZZZS;
     },
     get availability() {
       return availabilityOverride || availabilityZZZS;
     },
     get availabilityOverride() {
       return availabilityOverride;
+    },
+    get availabilityZZZS() {
+      return availabilityZZZS;
     },
     get email() {
       return email;


### PR DESCRIPTION
Let's say this is one of many steps refactoring DoctorCard.

@bananica I've removed styled Tooltip(Changed) and created styled PageInfo.Override (combined style from InfoWrapper and Changed) 

Accepts component prop `accepts` is now string. It takes only "y" or "n". 

Does it make sense to add to date tooltip also `accepts -> rejects`?
![gp-mehle](https://user-images.githubusercontent.com/44704999/147468605-4bdb2e33-3a1d-4caf-8b50-a884e1ba30c8.png)

If she is retired does she still accepts?
![ped-prodanovic](https://user-images.githubusercontent.com/44704999/147468960-e00ecc3a-0f6b-4dcc-a765-1b99b89f6e31.png)

@miaerbus I think I fixed all browser console errors (non-boolean attributes) see: #104 

@lukarenko @stefanb are we going translate note?

