### PR TITLE
feat: ✨ add snackbar alert on mobile in map view

### DIFF
--- a/src/components/Doctors/MapOnlySnackbar.js
+++ b/src/components/Doctors/MapOnlySnackbar.js
@@ -15,7 +15,7 @@ const Snackbar = styled(MuiSnackbar)(() => ({
 
 const Alert = forwardRef((props, ref) => (
   // eslint-disable-next-line react/jsx-props-no-spreading
-  <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />
+  <MuiAlert elevation={6} ref={ref} {...props} />
 ));
 
 const MapOnlySnackbar = function MapOnlySnackbar({ noResults }) {
@@ -47,7 +47,7 @@ const MapOnlySnackbar = function MapOnlySnackbar({ noResults }) {
       onClose={handleClose}
       anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
     >
-      <Alert onClose={handleClose} severity="error" sx={{ width: '100%' }}>
+      <Alert onClose={handleClose} severity="info" sx={{ width: '100%' }}>
         {t('noResults')}
       </Alert>
     </Snackbar>

--- a/src/components/Doctors/MapOnlySnackbar.js
+++ b/src/components/Doctors/MapOnlySnackbar.js
@@ -1,0 +1,60 @@
+import { forwardRef, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { useTranslation } from 'react-i18next';
+import { styled } from '@mui/material/styles';
+
+import MuiSnackbar from '@mui/material/Snackbar';
+import MuiAlert from '@mui/material/Alert';
+
+const Snackbar = styled(MuiSnackbar)(() => ({
+  '&.MuiSnackbar-anchorOriginTopCenter': {
+    top: '96px',
+  },
+}));
+
+const Alert = forwardRef((props, ref) => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />
+));
+
+const MapOnlySnackbar = function MapOnlySnackbar({ noResults }) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(noResults);
+
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    if (!noResults) {
+      setOpen(false);
+    }
+
+    if (noResults) {
+      setOpen(true);
+    }
+  }, [noResults]);
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={6000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+    >
+      <Alert onClose={handleClose} severity="error" sx={{ width: '100%' }}>
+        {t('noResults')}
+      </Alert>
+    </Snackbar>
+  );
+};
+
+MapOnlySnackbar.propTypes = {
+  noResults: PropTypes.bool.isRequired,
+};
+export default MapOnlySnackbar;

--- a/src/components/Doctors/MapOnlySnackbar.js
+++ b/src/components/Doctors/MapOnlySnackbar.js
@@ -7,9 +7,13 @@ import { styled } from '@mui/material/styles';
 import MuiSnackbar from '@mui/material/Snackbar';
 import MuiAlert from '@mui/material/Alert';
 
-const Snackbar = styled(MuiSnackbar)(() => ({
+const Snackbar = styled(MuiSnackbar)(({ theme }) => ({
   '&.MuiSnackbar-anchorOriginTopCenter': {
     top: '96px',
+  },
+
+  [theme.breakpoints.up('md')]: {
+    display: 'none',
   },
 }));
 

--- a/src/components/Doctors/index.js
+++ b/src/components/Doctors/index.js
@@ -1,18 +1,24 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { filterContext } from 'context';
-import DoctorCard from 'components/DoctorCard';
-import { useLeafletContext } from 'context/leafletContext';
-import { MAP } from 'const';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import L from 'leaflet';
+
 import { Alert } from '@mui/material';
-import * as Styled from './styles';
-import { MainScrollTop } from '../Shared/ScrollTop';
+
+import { MAP } from 'const';
+
+import { filterContext } from 'context';
+import { useLeafletContext } from 'context/leafletContext';
+
+import DoctorCard from 'components/DoctorCard';
 import MainMap from './Map';
+import { MainScrollTop } from '../Shared/ScrollTop';
 import FooterInfoCard from '../Shared/FooterInfo';
 import { CardsList } from '../Shared/Loader';
+import MapOnlySnackbar from './MapOnlySnackbar';
+
+import * as Styled from './styles';
 
 const { GEO_LOCATION, BOUNDS } = MAP;
 
@@ -21,6 +27,7 @@ const corner2 = L.latLng(...Object.values(BOUNDS.northEast));
 const bounds = L.latLngBounds(corner1, corner2);
 
 const Doctors = function Doctors({ itemsPerPage = 10, useShow }) {
+  const { t } = useTranslation();
   const { state } = useLocation();
   const { doctors, doctorType, accept, searchValue } = filterContext.useFilter();
   const [show, setShow] = useShow();
@@ -61,13 +68,10 @@ const Doctors = function Doctors({ itemsPerPage = 10, useShow }) {
 
   return (
     <Styled.Wrapper show={show}>
+      <MapOnlySnackbar noResults={show === 'map' && noResults} />
       <MainMap className="map" whenCreated={setMap} doctors={doctors} center={center} zoom={zoom} />
       <Styled.WrapperInfinite id="scrollableDiv" className="cards">
-        {noResults && (
-          <Alert sx={{ margin: '24px', borderRadius: '5px' }} severity="info">
-            {t('noResults')}
-          </Alert>
-        )}
+        {noResults && <Alert severity="info">{t('noResults')}</Alert>}
         {dataLoading && <CardsList />}
         <Styled.InfiniteScroll
           id="infiniteScroll"


### PR DESCRIPTION
Which colour do you prefer? Should it be blue like on list view or vice versa?


curent red filled:
![map-empty-snackbar](https://user-images.githubusercontent.com/44704999/147582806-a59802f1-347f-476f-b584-b770ea83fadb.png)

second-option red:
![map-empty-alert](https://user-images.githubusercontent.com/44704999/147582885-e7dd881f-5ddc-4e64-b76a-f5340219d85a.png)

list view current blue:
![list-empty-alert](https://user-images.githubusercontent.com/44704999/147583050-7f8450fe-b04c-45f2-bddc-52ecc4f36450.png)

