### PR TITLE
Add error boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prop-types": "^15.8.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-error-boundary": "^3.1.4",
     "react-helmet-async": "^1.2.2",
     "react-i18next": "^11.15.1",
     "react-infinite-scroll-component": "^6.1.0",

--- a/src/components/DoctorCard/index.js
+++ b/src/components/DoctorCard/index.js
@@ -7,6 +7,7 @@ import DoctorMap from './Map';
 import * as Styled from './styles';
 import Info from './Info';
 import PageInfo from './PageInfo';
+import { withErrorBoundary } from '../Shared/ErrorBoundary';
 
 const DoctorCard = function DoctorCard({
   doctor,
@@ -47,4 +48,4 @@ const DoctorCard = function DoctorCard({
 };
 
 const propsAreEqual = (prevProps, nextProps) => prevProps.doctor.key === nextProps.doctor.key;
-export default memo(DoctorCard, propsAreEqual);
+export default memo(withErrorBoundary(DoctorCard), propsAreEqual);

--- a/src/components/Doctors/Map.js
+++ b/src/components/Doctors/Map.js
@@ -5,6 +5,7 @@ import Leaflet from 'components/Shared/Leaflet';
 import * as Markers from './Markers';
 import MapEvents from './MapEvents';
 import 'react-leaflet-markercluster/dist/styles.min.css';
+import { withErrorBoundary } from '../Shared/ErrorBoundary';
 
 const { GEO_LOCATION } = MAP;
 
@@ -39,4 +40,4 @@ function withLeaflet(Component) {
   return DoctorsMap;
 }
 
-export default withLeaflet(Leaflet);
+export default withErrorBoundary(withLeaflet(Leaflet));

--- a/src/components/Doctors/index.js
+++ b/src/components/Doctors/index.js
@@ -19,6 +19,7 @@ import { CardsList } from '../Shared/Loader';
 import MapOnlySnackbar from './MapOnlySnackbar';
 
 import * as Styled from './styles';
+import { withErrorBoundary } from '../Shared/ErrorBoundary';
 
 const { GEO_LOCATION, BOUNDS } = MAP;
 
@@ -95,7 +96,7 @@ const Doctors = function Doctors({ itemsPerPage = 10, useShow }) {
   );
 };
 
-export default Doctors;
+export default withErrorBoundary(Doctors);
 
 export function getCenter(doctors) {
   const isArray = Array.isArray(doctors);

--- a/src/components/Filters/index.js
+++ b/src/components/Filters/index.js
@@ -13,6 +13,7 @@ import ToggleMapCards from './ToggleMapCards';
 import Search from './Search';
 
 import * as Styled from './styles';
+import { withErrorBoundary } from '../Shared/ErrorBoundary';
 
 const DoctorTypeIcons = {
   gp: <Icons.Icon name="Family" />,
@@ -112,4 +113,4 @@ const Filters = function Filters({ useShow }) {
   return matches ? up : down;
 };
 
-export default Filters;
+export default withErrorBoundary(Filters);

--- a/src/components/Shared/ErrorBoundary.js
+++ b/src/components/Shared/ErrorBoundary.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { t } from 'i18next';
+import { ErrorBoundary } from 'react-error-boundary';
+import PropTypes from 'prop-types';
+
+/**
+ * Error boundary higher-order component for unhandled errors
+ * @example
+ * export default withErrorBoundary(App)
+ */
+export const withErrorBoundary = WrappedComponent =>
+  function renderComponent({ ...props }) {
+    return (
+      <ErrorBoundaryWrapper>
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+        <WrappedComponent {...props} />
+      </ErrorBoundaryWrapper>
+    );
+  };
+
+const FallbackComponent = function FallbackComponent() {
+  return <div>{t('error.title')}</div>;
+};
+
+/**
+ * Error boundary component for unhandled errors
+ * @example
+ * <ErrorBoundaryWrapper><App /></ErrorBoundaryWrapper>
+ */
+const ErrorBoundaryWrapper = function ErrorBoundaryWrapper({ children }) {
+  return <ErrorBoundary fallbackRender={FallbackComponent}>{children}</ErrorBoundary>;
+};
+
+ErrorBoundaryWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default ErrorBoundaryWrapper;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -74,6 +74,9 @@
             "note": "note"
         }
     },
+    "error": {
+        "title": "Something went wrong"
+    },
     "footer": {
         "dataSource": "Data source",
         "lastChange": "Last data update on"

--- a/src/locales/sl.json
+++ b/src/locales/sl.json
@@ -74,6 +74,9 @@
             "note": "opomba"
         }
     },
+    "error": {
+        "title": "Nekaj je šlo narobe"
+    },
     "footer": {
         "dataSource": "Vir podatkov",
         "lastChange": "Zadnja sprememba"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9706,6 +9706,13 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"


### PR DESCRIPTION
Issue: https://github.com/sledilnik/zdravniki/issues/177#event-5827484737

I have included two approaches HOC and normal functional components.

**Examples:**
```jsx
// HOC
export default withErrorBoundary(App);

// Component 
<ErrorBoundaryWrapper>
  <App />
</ErrorBoundaryWrapper>
```

**Results:**
When doctor's data is corrupted:
![image](https://user-images.githubusercontent.com/40028548/147754325-5baba106-94ae-4cfd-8e69-c157aa71629f.png)
If map throws an error:
![image](https://user-images.githubusercontent.com/40028548/147754462-322ca3cd-8df4-48cf-a1ff-144168e4e35a.png)

**potential improvement:**
- Better error text
- ErrorBoundary could accept custom fallback component or text as a param