### PR TITLE
Map marker cluster color should be informative

### DIFF
--- a/src/components/Doctors/Map.js
+++ b/src/components/Doctors/Map.js
@@ -10,6 +10,31 @@ import { DoctorPropType } from '../../types';
 
 const { GEO_LOCATION } = MAP;
 
+const createClusterCustomIcon = function (cluster) {
+  let n;
+  let acceptsCnt = 0;
+  // eslint-disable-next-line no-restricted-syntax
+  for (n in cluster.getAllChildMarkers()) {
+    if (Object.prototype.hasOwnProperty.call(cluster.getAllChildMarkers(), n)) {
+      acceptsCnt += cluster.getAllChildMarkers()[n].options.accepts === 'y' ? 1 : 0;
+    }
+  }
+  let acceptsPercentage = Math.round(((acceptsCnt / cluster.getChildCount()) * 10) / 2.5) * 25;
+  if (acceptsPercentage === 100 && acceptsCnt !== cluster.getChildCount()) {
+    acceptsPercentage = 75;
+  } else if (acceptsPercentage === 0 && acceptsCnt > 0) {
+    acceptsPercentage = 25;
+  }
+
+  // eslint-disable-next-line no-undef
+  return L.divIcon({
+    html: `<div><span>${cluster.getChildCount()}</span></div>`,
+    className: `marker-cluster marker-cluster-small marker-cluster-accepts-${acceptsPercentage}`,
+    // eslint-disable-next-line no-undef
+    iconSize: L.point(40, 40, true),
+  });
+};
+
 function withLeaflet(Component) {
   const DoctorsMap = function DoctorsMap({
     doctors,
@@ -31,7 +56,9 @@ function withLeaflet(Component) {
 
     return (
       <Component {...injectedProps}>
-        <MarkerClusterGroup maxClusterRadius={40}>{markers}</MarkerClusterGroup>
+        <MarkerClusterGroup iconCreateFunction={createClusterCustomIcon} maxClusterRadius={40}>
+          {markers}
+        </MarkerClusterGroup>
         {userLocation && <Markers.User />}
         <MapEvents />
       </Component>

--- a/src/components/Doctors/Markers.js
+++ b/src/components/Doctors/Markers.js
@@ -45,6 +45,7 @@ export const Doctor = memo(({ doctor }) => {
       ref={ref}
       center={doctor.geoLocation}
       radius={12}
+      accepts={doctor.accepts}
       stroke={false}
       fillOpacity={0.7}
       fillColor={fillColor}

--- a/src/pages/styles/Home.js
+++ b/src/pages/styles/Home.js
@@ -17,21 +17,20 @@ export const Box = styled(MuiBox)(({ theme }) => ({
       backgroundColor: 'inherit',
       display: 'block',
       borderRadius: 100,
+      textShadow: '0 0 3px #ffffff90',
     },
   },
 
   '.marker-cluster-accepts-0': {
     backgroundColor: '#CC0C1E45',
     span: {
-      color: lighten('#CC0C1E', 0.9),
-      textShadow: '0 0 3px #00000080',
+      color: darken('#CC0C1E', 0.6),
     },
   },
   '.marker-cluster-accepts-25': {
     backgroundColor: '#FF440045',
     span: {
-      color: lighten('#FF4400', 0.9),
-      textShadow: '0 0 3px #00000080',
+      color: darken('#FF4400', 0.6),
     },
   },
   '.marker-cluster-accepts-50': {

--- a/src/pages/styles/Home.js
+++ b/src/pages/styles/Home.js
@@ -1,5 +1,5 @@
 import MuiBox from '@mui/material/Box';
-import { darken, lighten, styled } from '@mui/material/styles';
+import { darken, styled } from '@mui/material/styles';
 
 import { SIZES } from 'const';
 

--- a/src/pages/styles/Home.js
+++ b/src/pages/styles/Home.js
@@ -22,33 +22,33 @@ export const Box = styled(MuiBox)(({ theme }) => ({
   },
 
   '.marker-cluster-accepts-0': {
-    backgroundColor: '#CC0C1E45',
+    backgroundColor: '#d32f2f45',
     span: {
-      color: darken('#CC0C1E', 0.6),
+      color: darken('#d32f2f', 0.6),
     },
   },
   '.marker-cluster-accepts-25': {
-    backgroundColor: '#FF440045',
+    backgroundColor: '#EF741F45',
     span: {
-      color: darken('#FF4400', 0.6),
+      color: darken('#EF741F', 0.6),
     },
   },
   '.marker-cluster-accepts-50': {
-    backgroundColor: '#FF6C0045',
+    backgroundColor: '#FFA80045',
     span: {
-      color: darken('#FF6C00', 0.6),
+      color: darken('#FFA800', 0.6),
     },
   },
   '.marker-cluster-accepts-75': {
-    backgroundColor: '#F7AD1F45',
+    backgroundColor: '#AEB11845',
     span: {
-      color: darken('#F7AD1F', 0.6),
+      color: darken('#AEB118', 0.6),
     },
   },
   '.marker-cluster-accepts-100': {
-    backgroundColor: '#78B90B45',
+    backgroundColor: '#2e7d3245',
     span: {
-      color: darken('#78B90B', 0.6),
+      color: darken('#2e7d32', 0.6),
     },
   },
 

--- a/src/pages/styles/Home.js
+++ b/src/pages/styles/Home.js
@@ -1,5 +1,5 @@
 import MuiBox from '@mui/material/Box';
-import { styled } from '@mui/material/styles';
+import { darken, lighten, styled } from '@mui/material/styles';
 
 import { SIZES } from 'const';
 
@@ -11,13 +11,46 @@ export const Box = styled(MuiBox)(({ theme }) => ({
   '& .leaflet-container': {
     height: SIZES.MAP_HEIGHT.default,
   },
-
-  '.marker-cluster-small, .marker-cluster-medium, .marker-cluster-large': {
-    backgroundColor: `${theme.customColors.brand}40`,
-  },
   '.marker-cluster-small div, .marker-cluster-medium div, .marker-cluster-large div': {
-    opacity: 0.7,
-    backgroundColor: theme.customColors.brand,
+    backgroundColor: 'inherit',
+    span: {
+      backgroundColor: 'inherit',
+      display: 'block',
+      borderRadius: 100,
+    },
+  },
+
+  '.marker-cluster-accepts-0': {
+    backgroundColor: '#CC0C1E45',
+    span: {
+      color: lighten('#CC0C1E', 0.9),
+      textShadow: '0 0 3px #00000080',
+    },
+  },
+  '.marker-cluster-accepts-25': {
+    backgroundColor: '#FF440045',
+    span: {
+      color: lighten('#FF4400', 0.9),
+      textShadow: '0 0 3px #00000080',
+    },
+  },
+  '.marker-cluster-accepts-50': {
+    backgroundColor: '#FF6C0045',
+    span: {
+      color: darken('#FF6C00', 0.6),
+    },
+  },
+  '.marker-cluster-accepts-75': {
+    backgroundColor: '#F7AD1F45',
+    span: {
+      color: darken('#F7AD1F', 0.6),
+    },
+  },
+  '.marker-cluster-accepts-100': {
+    backgroundColor: '#78B90B45',
+    span: {
+      color: darken('#78B90B', 0.6),
+    },
   },
 
   [theme.breakpoints.up('sm')]: {


### PR DESCRIPTION
- Map marker cluster color should be based on the % of doctors who accept new patients
- Green 100% if all doctors accept, red none do, and 3 shades in between (25, 50, 75%)
- Round it to 25% so there's not too much shades
- Up to 25% color even if just 1 doctor accepts
- Down to 75% color even if just 1 doctor does not accept

I tried first with light text on darker cluster colors, atm all are dark, here are screenshots of both.
Comments welcome.

![PixelSnap 2022-01-04 at 23 30 55](https://user-images.githubusercontent.com/6833025/148132805-d281caa1-3715-4f3d-b840-c7794252f84f.png)

![PixelSnap 2022-01-04 at 23 37 30](https://user-images.githubusercontent.com/6833025/148133484-ed85d70b-90f8-4aa3-b714-755b052be6f1.png)

