### PR TITLE
Fix: multiple doctor's websites as single link

### DIFF
--- a/src/components/DoctorCard/Info/index.js
+++ b/src/components/DoctorCard/Info/index.js
@@ -24,11 +24,12 @@ const Info = function Info({ doctor, handleZoom = () => {}, isMarker = false }) 
 
   const handleDoctorCard = (event, isReportError) => {
     event.preventDefault();
+    const center = map?.getCenter();
 
     navigate(path, {
       state: {
         zoom: map?.getZoom(),
-        center: map?.getCenter(),
+        center: center ? [center.lat, center.lng] : undefined,
         isReportError,
         type,
         ageGroup: ageGroup ?? 'adults',

--- a/src/components/DoctorCard/PageInfo/PhoneLinks.js
+++ b/src/components/DoctorCard/PageInfo/PhoneLinks.js
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import DoctorLinks from '../Shared/DoctorLinks';
+
+function withDoctorLinks(Component) {
+  const PhoneLinks = function PhoneLinks({ phone }) {
+    const phones = phone
+      ?.split(',')
+      .map(p => p.trim() && new URL(`tel:${p.trim()}`))
+      .filter(p => Boolean(p));
+
+    return <Component links={phones} iconName="PhoneBig" />;
+  };
+
+  PhoneLinks.propTypes = {
+    phone: PropTypes.string.isRequired,
+  };
+
+  return PhoneLinks;
+}
+
+export default withDoctorLinks(DoctorLinks);

--- a/src/components/DoctorCard/PageInfo/WebsiteLinks.js
+++ b/src/components/DoctorCard/PageInfo/WebsiteLinks.js
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import DoctorLinks from '../Shared/DoctorLinks';
+
+function withDoctorLinks(Component) {
+  const WebsiteLinks = function WebsiteLinks({ website }) {
+    const websites = website
+      ?.split(',')
+      .map(w => {
+        const url = w?.trim();
+        if (url.startsWith('http')) {
+          return new URL(url);
+        }
+        return new URL(`http://${url}`);
+      })
+      .filter(w => Boolean(w));
+
+    return <Component links={websites} iconName="LinkBig" />;
+  };
+
+  WebsiteLinks.propTypes = {
+    website: PropTypes.string.isRequired,
+  };
+
+  return WebsiteLinks;
+}
+
+export default withDoctorLinks(DoctorLinks);

--- a/src/components/DoctorCard/PageInfo/WebsiteLinks.js
+++ b/src/components/DoctorCard/PageInfo/WebsiteLinks.js
@@ -7,6 +7,9 @@ function withDoctorLinks(Component) {
       ?.split(',')
       .map(w => {
         const url = w?.trim();
+        if (!url) {
+          return null;
+        }
         if (url.startsWith('http')) {
           return new URL(url);
         }

--- a/src/components/DoctorCard/PageInfo/index.js
+++ b/src/components/DoctorCard/PageInfo/index.js
@@ -128,8 +128,8 @@ const PageInfo = function PageInfo({ doctor }) {
           </Alert>
         )}
         <Styled.PageInfo.LinksMenuWrapper>
-          {doctor.website && <Shared.PageInfoPhones phones={websites} isWebsite />}
-          {doctor.phone && <Shared.PageInfoPhones phones={phones} />}
+          {doctor.website && <Shared.DoctorLinks links={websites} isWebsite />}
+          {doctor.phone && <Shared.DoctorLinks links={phones} />}
           {emailText && (
             <Styled.PageInfo.LinkWrapper direction="row" alignItems="center" spacing={1}>
               <Typography component="div" variant="body1">

--- a/src/components/DoctorCard/PageInfo/index.js
+++ b/src/components/DoctorCard/PageInfo/index.js
@@ -10,6 +10,8 @@ import * as Icons from 'components/Shared/Icons';
 import { MAP } from 'const';
 
 import ReportError from '../ReportError';
+import WebsiteLinks from './WebsiteLinks';
+import PhoneLinks from './PhoneLinks';
 import * as Styled from '../styles';
 import * as Shared from '../Shared';
 
@@ -74,21 +76,6 @@ const PageInfo = function PageInfo({ doctor }) {
     );
   }
 
-  const websites = doctor.website
-    ?.split(',')
-    .map(w => {
-      const url = w?.trim();
-      if (url.startsWith('http')) {
-        return new URL(url);
-      }
-      return new URL(`http://${url}`);
-    })
-    .filter(w => Boolean(w));
-  const phones = doctor.phone
-    ?.split(',')
-    .map(p => p.trim() && new URL(`tel:${p.trim()}`))
-    .filter(p => Boolean(p));
-
   // todo create component for urls -> website, orderform
 
   return (
@@ -128,8 +115,8 @@ const PageInfo = function PageInfo({ doctor }) {
           </Alert>
         )}
         <Styled.PageInfo.LinksMenuWrapper>
-          {doctor.website && <Shared.DoctorLinks links={websites} iconName="LinkBig" />}
-          {doctor.phone && <Shared.DoctorLinks links={phones} iconName="PhoneBig" />}
+          {doctor.website && <WebsiteLinks website={doctor.website} />}
+          {doctor.phone && <PhoneLinks phone={doctor.phone} />}
           {emailText && (
             <Styled.PageInfo.LinkWrapper direction="row" alignItems="center" spacing={1}>
               <Typography component="div" variant="body1">

--- a/src/components/DoctorCard/PageInfo/index.js
+++ b/src/components/DoctorCard/PageInfo/index.js
@@ -25,7 +25,6 @@ const PageInfo = function PageInfo({ doctor }) {
 
   const [type, ageGroup] = doctor.type.split('-');
 
-  const websiteText = doctor.website && new URL(doctor.website).host;
   const emailText = doctor.email;
   const orderformText = doctor.orderform && t('orderform');
   const isReportError = state?.isReportError ?? false;
@@ -75,6 +74,19 @@ const PageInfo = function PageInfo({ doctor }) {
     );
   }
 
+  const websites = doctor.website
+    ?.split(',')
+    .map(w => {
+      const url = w?.trim();
+      if (url.startsWith('www')) {
+        return new URL(`http://${url}`);
+      }
+      if (url.startsWith('http')) {
+        return new URL(url);
+      }
+      return null;
+    })
+    .filter(w => Boolean(w));
   const phones = doctor.phone?.split(',');
 
   // todo create component for urls -> website, orderform
@@ -116,16 +128,7 @@ const PageInfo = function PageInfo({ doctor }) {
           </Alert>
         )}
         <Styled.PageInfo.LinksMenuWrapper>
-          {websiteText && (
-            <Styled.PageInfo.LinkWrapper direction="row" alignItems="center" spacing={1}>
-              <Typography component="div" variant="body1">
-                <Icons.Icon name="LinkBig" />
-              </Typography>
-              <Shared.ConditionalLink to={doctor.website} variant="body1">
-                {websiteText}
-              </Shared.ConditionalLink>
-            </Styled.PageInfo.LinkWrapper>
-          )}
+          {doctor.website && <Shared.PageInfoPhones phones={websites} isWebsite />}
           {doctor.phone && <Shared.PageInfoPhones phones={phones} />}
           {emailText && (
             <Styled.PageInfo.LinkWrapper direction="row" alignItems="center" spacing={1}>

--- a/src/components/DoctorCard/PageInfo/index.js
+++ b/src/components/DoctorCard/PageInfo/index.js
@@ -78,16 +78,16 @@ const PageInfo = function PageInfo({ doctor }) {
     ?.split(',')
     .map(w => {
       const url = w?.trim();
-      if (url.startsWith('www')) {
-        return new URL(`http://${url}`);
-      }
       if (url.startsWith('http')) {
         return new URL(url);
       }
-      return null;
+      return new URL(`http://${url}`);
     })
     .filter(w => Boolean(w));
-  const phones = doctor.phone?.split(',');
+  const phones = doctor.phone
+    ?.split(',')
+    .map(p => p.trim() && new URL(`tel:${p.trim()}`))
+    .filter(p => Boolean(p));
 
   // todo create component for urls -> website, orderform
 
@@ -128,8 +128,8 @@ const PageInfo = function PageInfo({ doctor }) {
           </Alert>
         )}
         <Styled.PageInfo.LinksMenuWrapper>
-          {doctor.website && <Shared.DoctorLinks links={websites} isWebsite />}
-          {doctor.phone && <Shared.DoctorLinks links={phones} />}
+          {doctor.website && <Shared.DoctorLinks links={websites} iconName="LinkBig" />}
+          {doctor.phone && <Shared.DoctorLinks links={phones} iconName="PhoneBig" />}
           {emailText && (
             <Styled.PageInfo.LinkWrapper direction="row" alignItems="center" spacing={1}>
               <Typography component="div" variant="body1">

--- a/src/components/DoctorCard/Shared/DoctorLinks.js
+++ b/src/components/DoctorCard/Shared/DoctorLinks.js
@@ -8,7 +8,7 @@ import * as Links from './Links';
 
 const DoctorLinks = function DoctorLinks({ links, iconName }) {
   const phoneLinks = links.map((link, index, arr) => {
-    const text = link.host || link.pathname;
+    const text = link.host?.replace('www.', '') || link.pathname;
     const isWebsite = link.protocol.startsWith('http');
     const key = isWebsite ? `website-${link.href}` : `tel-${link.href}`;
     const isLastLink = index === arr.length - 1;

--- a/src/components/DoctorCard/Shared/DoctorLinks.js
+++ b/src/components/DoctorCard/Shared/DoctorLinks.js
@@ -6,13 +6,14 @@ import * as Icons from 'components/Shared/Icons';
 import * as Styled from '../styles';
 import * as Links from './Links';
 
-const PageInfoPhones = function PhoneInfoPhone({ phones, isWebsite }) {
-  const phoneLinks = phones.map((phone, index, arr) => {
+const DoctorLinks = function DoctorLinks({ links, isWebsite }) {
+  const phoneLinks = links.map((phone, index, arr) => {
     const href = isWebsite ? phone.href : `tel:${phone?.trim()}`;
     const text = isWebsite ? phone.host : phone;
+    const key = isWebsite ? `website-${phone.href}` : phone;
     return (
       <Links.ConditionalLink
-        key={`phone-num${href}`}
+        key={key}
         to={phone && href}
         self={isWebsite ? undefined : true}
         variant="body1"
@@ -37,14 +38,14 @@ const PageInfoPhones = function PhoneInfoPhone({ phones, isWebsite }) {
   );
 };
 
-PageInfoPhones.defaultProps = {
-  phones: [],
+DoctorLinks.defaultProps = {
+  links: [],
   isWebsite: undefined,
 };
 
-PageInfoPhones.propTypes = {
-  phones: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(URL)])),
+DoctorLinks.propTypes = {
+  links: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(URL)])),
   isWebsite: PropTypes.bool,
 };
 
-export default PageInfoPhones;
+export default DoctorLinks;

--- a/src/components/DoctorCard/Shared/DoctorLinks.js
+++ b/src/components/DoctorCard/Shared/DoctorLinks.js
@@ -6,27 +6,24 @@ import * as Icons from 'components/Shared/Icons';
 import * as Styled from '../styles';
 import * as Links from './Links';
 
-const DoctorLinks = function DoctorLinks({ links, isWebsite }) {
-  const phoneLinks = links.map((phone, index, arr) => {
-    const href = isWebsite ? phone.href : `tel:${phone?.trim()}`;
-    const text = isWebsite ? phone.host : phone;
-    const key = isWebsite ? `website-${phone.href}` : phone;
+const DoctorLinks = function DoctorLinks({ links, iconName }) {
+  const phoneLinks = links.map((link, index, arr) => {
+    const text = link.host || link.pathname;
+    const isWebsite = link.protocol.startsWith('http');
+    const key = isWebsite ? `website-${link.href}` : `tel-${link.href}`;
+    const isLastLink = index === arr.length - 1;
+
     return (
-      <Links.ConditionalLink
-        key={key}
-        to={phone && href}
-        self={isWebsite ? undefined : true}
-        variant="body1"
-      >
+      <Links.ConditionalLink key={key} to={link.href} self={!isWebsite} variant="body1">
         {text}
-        <Typography component="span" variant="body1">
-          {index !== arr.length - 1 && ', '}
-        </Typography>
+        {!isLastLink && (
+          <Typography component="span" variant="body1">
+            ,{' '}
+          </Typography>
+        )}
       </Links.ConditionalLink>
     );
   });
-
-  const iconName = isWebsite ? 'LinkBig' : 'PhoneBig';
 
   return (
     <Styled.PageInfo.LinkWrapper direction="row" alignItems="center" spacing={1}>
@@ -40,12 +37,11 @@ const DoctorLinks = function DoctorLinks({ links, isWebsite }) {
 
 DoctorLinks.defaultProps = {
   links: [],
-  isWebsite: undefined,
 };
 
 DoctorLinks.propTypes = {
   links: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(URL)])),
-  isWebsite: PropTypes.bool,
+  iconName: PropTypes.oneOf(Object.values(Icons.ICON_KEYS)).isRequired,
 };
 
 export default DoctorLinks;

--- a/src/components/DoctorCard/Shared/Links.js
+++ b/src/components/DoctorCard/Shared/Links.js
@@ -50,7 +50,7 @@ export const ConditionalLink = function ConditionalLink({
   ...props
 }) {
   const link = (
-    <Link href={to} self={self ? true : undefined}>
+    <Link href={to} self={self}>
       {children}
     </Link>
   );

--- a/src/components/DoctorCard/Shared/Links.js
+++ b/src/components/DoctorCard/Shared/Links.js
@@ -16,7 +16,7 @@ export const Link = function Link({ children, self, ...props }) {
 
 Link.propTypes = {
   children: ChildrenPropType,
-  self: PropTypes.string,
+  self: PropTypes.bool,
 };
 
 Link.defaultProps = {
@@ -50,7 +50,7 @@ export const ConditionalLink = function ConditionalLink({
   ...props
 }) {
   const link = (
-    <Link href={to} self={self}>
+    <Link href={to} self={self ? true : undefined}>
       {children}
     </Link>
   );
@@ -65,7 +65,7 @@ ConditionalLink.propTypes = {
   children: ChildrenPropType,
   to: PropTypes.string,
   component: PropTypes.string,
-  self: PropTypes.string,
+  self: PropTypes.bool,
 };
 
 ConditionalLink.defaultProps = {

--- a/src/components/DoctorCard/Shared/PageInfoPhones.js
+++ b/src/components/DoctorCard/Shared/PageInfoPhones.js
@@ -6,17 +6,18 @@ import * as Icons from 'components/Shared/Icons';
 import * as Styled from '../styles';
 import * as Links from './Links';
 
-const PageInfoPhones = function PhoneInfoPhone({ phones }) {
+const PageInfoPhones = function PhoneInfoPhone({ phones, isWebsite }) {
   const phoneLinks = phones.map((phone, index, arr) => {
-    const phoneNum = phone?.trim();
+    const href = isWebsite ? phone.href : `tel:${phone?.trim()}`;
+    const text = isWebsite ? phone.host : phone;
     return (
       <Links.ConditionalLink
-        key={`phone-num${phoneNum}`}
-        to={phone && `tel:${phoneNum}`}
-        self
+        key={`phone-num${href}`}
+        to={phone && href}
+        self={isWebsite ? undefined : true}
         variant="body1"
       >
-        {phone}
+        {text}
         <Typography component="span" variant="body1">
           {index !== arr.length - 1 && ', '}
         </Typography>
@@ -24,10 +25,12 @@ const PageInfoPhones = function PhoneInfoPhone({ phones }) {
     );
   });
 
+  const iconName = isWebsite ? 'LinkBig' : 'PhoneBig';
+
   return (
     <Styled.PageInfo.LinkWrapper direction="row" alignItems="center" spacing={1}>
       <Typography component="div" variant="body1">
-        <Icons.Icon name="PhoneBig" />
+        <Icons.Icon name={iconName} />
       </Typography>
       {phoneLinks}
     </Styled.PageInfo.LinkWrapper>
@@ -36,10 +39,12 @@ const PageInfoPhones = function PhoneInfoPhone({ phones }) {
 
 PageInfoPhones.defaultProps = {
   phones: [],
+  isWebsite: undefined,
 };
 
 PageInfoPhones.propTypes = {
-  phones: PropTypes.arrayOf(PropTypes.string),
+  phones: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(URL)])),
+  isWebsite: PropTypes.bool,
 };
 
 export default PageInfoPhones;

--- a/src/components/DoctorCard/Shared/index.js
+++ b/src/components/DoctorCard/Shared/index.js
@@ -26,7 +26,7 @@ export * as Tooltip from './Tooltips';
 // it would be better to import just like Tooltip but don't want to make to many changes all over the code
 export { Link, LinkNoRel, ConditionalLink } from './Links';
 
-export { default as PageInfoPhones } from './PageInfoPhones';
+export { default as DoctorLinks } from './DoctorLinks';
 export { default as PhoneButton } from './PhoneButton';
 export { default as Accepts } from './Accepts';
 

--- a/src/components/Filters/styles/Search.js
+++ b/src/components/Filters/styles/Search.js
@@ -49,7 +49,7 @@ export const InputBase = styled(MuiInputBase)(() => {
   const paddingRight = `${48 * scaleUpRatio}px`;
   const paddingLeft = `${(16 + 32) * scaleUpRatio}px`;
   const width = `${100 * scaleUpRatio}%`;
-  const searchDecorator = { '-webkit-appearance': 'none' };
+  const searchDecorator = { WebkitAppearance: 'none' };
 
   const transform = `scale(${scaleDownRatio})`;
 

--- a/src/components/Shared/Icons.js
+++ b/src/components/Shared/Icons.js
@@ -122,7 +122,7 @@ export const Icon = function Icon({ name, ...props }) {
   return Component ? <Component {...props} /> : null;
 };
 
-const ICON_KEYS = Object.keys(icons);
+export const ICON_KEYS = Object.keys(icons);
 
 Icon.propTypes = {
   name: PropTypes.oneOf(ICON_KEYS).isRequired,


### PR DESCRIPTION
before:
![148656726-0a6dc765-6eae-48a2-8914-f08247cd90a9](https://user-images.githubusercontent.com/44704999/148666773-8e3716d5-a6b7-4642-ba3e-b96d9b01cc28.png)

after:
![Screenshot 2022-01-09 03 26 29](https://user-images.githubusercontent.com/44704999/148666777-05f012f6-21da-47ee-b805-bae63fabba3e.png)

Also fixes some browser errors (camelCase css property and some `prop-types` errors).

@mitjapotocin please check if `<Search/>` still looks the same.