### PR TITLE
fix: 🐛 no map at md breakpoint

### DIFF
--- a/src/components/DoctorCard/styles/index.js
+++ b/src/components/DoctorCard/styles/index.js
@@ -90,13 +90,13 @@ export const PageInfoBox = styled(Stack)(({ theme }) => ({
       '.leaflet-container': {
         zIndex: 1,
         width: '100%',
-        height: '100%',
-        borderRadius: '0 0 5px 0',
+        height: '350px',
+        borderRadius: '0 0 5px 5px',
       },
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.up('md')]: {
         '.leaflet-container': {
-          height: '350px',
-          borderRadius: '0 0 5px 5px',
+          borderRadius: '0 5px 5px 0',
+          height: '100%',
         },
       },
     },


### PR DESCRIPTION
On dr's page there is no map on info card on medium devices.

before:
![Screenshot 2023-03-02 at 15 18 28](https://user-images.githubusercontent.com/44704999/222455847-b80e9554-be04-464a-8395-c19ff61bee14.png)

after:
![Screenshot 2023-03-02 at 15 26 06](https://user-images.githubusercontent.com/44704999/222456134-c685fbe2-1ed3-4e0e-bb91-20fa1ad32d2c.png)
