### PR TITLE
Fix: Not supported languages in external nav links

### DIFF
--- a/src/components/Header/NavLinks.js
+++ b/src/components/Header/NavLinks.js
@@ -3,6 +3,7 @@ import i18next, { t } from 'i18next';
 import { useNavigate } from 'react-router-dom';
 import { useFilter } from 'context/filterContext';
 import * as Styled from './styles';
+import SledilnikOrgLinks from './SledilnikOrgLinks';
 
 const NavLinks = function NavLinks() {
   const navigate = useNavigate();
@@ -29,28 +30,7 @@ const NavLinks = function NavLinks() {
 
       <Styled.NavMenuLink to={`/${lng}/faq`}>{t('header.faq')}</Styled.NavMenuLink>
       <Styled.NavMenuLink to={`/${lng}/about`}>{t('header.about')}</Styled.NavMenuLink>
-      <Styled.NavMenuItemLink
-        href={`https://covid-19.sledilnik.org/${lng}/donate`}
-        target="_blank"
-        rel="noopener"
-        component="button"
-        tabIndex={0}
-        underline="none"
-        role="link"
-      >
-        {t('header.support')}
-      </Styled.NavMenuItemLink>
-      <Styled.NavMenuItemLink
-        href={`https://sledilnik.org/${lng}`}
-        target="_blank"
-        rel="noopener"
-        component="button"
-        tabIndex={0}
-        underline="none"
-        role="link"
-      >
-        {t('header.sledilnik')}
-      </Styled.NavMenuItemLink>
+      <SledilnikOrgLinks />
     </>
   );
 };

--- a/src/components/Header/SledilnikOrgLinks.jsx
+++ b/src/components/Header/SledilnikOrgLinks.jsx
@@ -1,0 +1,39 @@
+import i18next, { t } from 'i18next';
+
+import * as Styled from './styles';
+
+const SLEDILNIK_ORG_SUPPORTED_LNG = ['de', 'en', 'hr', 'it', 'sl'];
+
+const SledilnikOrgLinks = function SledilnikOrgLinks() {
+  const lng = i18next.language;
+  const supportedLng = SLEDILNIK_ORG_SUPPORTED_LNG.includes(lng) ? lng : 'en';
+
+  return (
+    <>
+      <Styled.NavMenuItemLink
+        href={`https://covid-19.sledilnik.org/${supportedLng}/donate`}
+        target="_blank"
+        rel="noopener"
+        component="button"
+        tabIndex={0}
+        underline="none"
+        role="link"
+      >
+        {t('header.support')}
+      </Styled.NavMenuItemLink>
+      <Styled.NavMenuItemLink
+        href={`https://sledilnik.org/${supportedLng}`}
+        target="_blank"
+        rel="noopener"
+        component="button"
+        tabIndex={0}
+        underline="none"
+        role="link"
+      >
+        {t('header.sledilnik')}
+      </Styled.NavMenuItemLink>
+    </>
+  );
+};
+
+export default SledilnikOrgLinks;


### PR DESCRIPTION
Adds new component `SledilnikOrgLinks` for links pointing to `sledilnik.org/[lng]`.

FIX: #452 