### PR TITLE
fix: 🚑️ not fallback langs on first load redirected to 404

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import i18n, { t } from 'i18next';
 import { THEME } from 'const';
 import Router from 'routes';
 import { useLocation } from 'react-router';
+import { supportedLanguages } from 'i18n';
 
 const App = function App() {
   const theme = createTheme(THEME);
@@ -17,7 +18,6 @@ const App = function App() {
 
   const pathnameLocale = pathname.split('/')?.[1].toLocaleLowerCase() ?? defaultLanguage;
 
-  const supportedLanguages = i18n.languages;
   const isLang = supportedLanguages.includes(pathnameLocale);
 
   const shouldChangeLanguage =

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -17,6 +17,8 @@ export const languages = [
   { name: 'Magyar', code: 'hu' },
 ];
 
+export const supportedLanguages = languages.map(value => value.code);
+
 i18next
   // .use(Backend) // load translations using http (default public/assets/locals/en/translations)
   .use(LanguageDetector)


### PR DESCRIPTION
https://sledilnik.slack.com/archives/CV93RSH17/p1709448743246669?thread_ts=1708892539.600929&cid=CV93RSH17

Before: Our router was getting supported languages from `initOptions.fallbackLng`
After: from resources `languages` variable

https://pr-461.zdravniki.sledilnik.org/de/
https://pr-461.zdravniki.sledilnik.org/hr/
https://pr-461.zdravniki.sledilnik.org/hu/
https://pr-461.zdravniki.sledilnik.org/it/