### PR TITLE
FIx: missing intl date format locales

### DIFF
--- a/src/components/DoctorCard/PageInfo/index.js
+++ b/src/components/DoctorCard/PageInfo/index.js
@@ -204,7 +204,7 @@ const PageInfo = function PageInfo({ doctor }) {
               leaveTouchDelay={3000}
               enterTouchDelay={50}
             >
-              <Styled.PageInfo.Override direction="row" alignItems="center" spacing={1}>
+              <Styled.PageInfo.Override direction="row" alignItems="center" gap="0.25rem">
                 <Icons.Icon name="Edit" /> {doctor.formatUpdatedAt(lng)}
               </Styled.PageInfo.Override>
             </Tooltip>

--- a/src/components/DoctorCard/styles/PageInfo.js
+++ b/src/components/DoctorCard/styles/PageInfo.js
@@ -122,7 +122,6 @@ export const Override = styled(Stack)(({ theme }) => ({
   borderRadius: '5px',
   padding: '5px 8px',
   svg: {
-    margin: '0 5px 0 0',
     opacity: '0.25',
   },
 }));

--- a/src/services/doctors.js
+++ b/src/services/doctors.js
@@ -80,6 +80,10 @@ export function createDoctor(doctor, inst) {
     const lngTranslate = {
       sl: 'sl-SL',
       en: 'en-GB',
+      de: 'de-DE',
+      it: 'it-IT',
+      hr: 'hr-HR',
+      hu: 'hu-HU',
     };
 
     return new Intl.DateTimeFormat(lngTranslate[lng]).format(new Date(dateOverride));


### PR DESCRIPTION
missing langs: it, de, hu and hr.
also, fix the missing gap in the date override

before /hu
https://zdravniki.sledilnik.org/hu/gp/ahcin-novak-rosana/205431
![Screenshot 2024-03-16 at 19 03 01](https://github.com/sledilnik/zdravniki/assets/44704999/af2798d4-49b2-47c4-aff9-2987ce39541d)

https://pr-475.zdravniki.sledilnik.org/sl/gp/ahcin-novak-rosana/205431
after /hu
![Screenshot 2024-03-16 at 19 03 11](https://github.com/sledilnik/zdravniki/assets/44704999/936b3c9d-10cf-4101-a98b-c762ac46662e)
